### PR TITLE
FIX : Typo in example Relax Mondrian with INFORMS data K=11

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Parameters:
 	python anonymizer.py s a 20
 
 	# run Relax Mondrian with INFORMS data K=11
-	python anonymizer.py r i 1
+	python anonymizer.py r i 11
 
 
 	# Evluating Strict Mondrian with k on adult data


### PR DESCRIPTION
The example mentioned in the README, uses a value of k, when it is mentioned for a value of 11
The change has been made via this PR